### PR TITLE
Nate158

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# tokenether.github.io
+n hiame: MSBuild
+
+on: [push]
+
+env:
+  # Path to the solution file relative to the root of the project.
+  SOLUTION_FILE_PATH: .
+
+  # Configuration type to build.
+  # You can convert this to a build matrix if you need coverage of multiple configuration types.
+  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  BUILD_CONFIGURATION: Release
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Restore NuGet packages
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Build
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}


### PR DESCRIPTION
n hiame: MSBuild

on: [push]

env:
  # Path to the solution file relative to the root of the project.
  SOLUTION_FILE_PATH: .

  # Configuration type to build.
  # You can convert this to a build matrix if you need coverage of multiple configuration types.
  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
  BUILD_CONFIGURATION: Release

jobs:
  build:
    runs-on: windows-latest

    steps:
    - uses: actions/checkout@v2

    - name: Add MSBuild to PATH
      uses: microsoft/setup-msbuild@v1.0.2

    - name: Restore NuGet packages
      working-directory: ${{env.GITHUB_WORKSPACE}}
      run: nuget restore ${{env.SOLUTION_FILE_PATH}}

    - name: Build
      working-directory: ${{env.GITHUB_WORKSPACE}}
      # Add additional options to the MSBuild command line here (like platform or verbosity level).
      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
package main

import (
    "regexp"
    "fmt"
)

func main() {
    var re = regexp.MustCompile(`(?m)[abc https://api.github.com/repos/rari capital/solmate/git/trees/ab1d04a2ba35cd63ebe90d3704ff0a010a576246]+`)
    var str = `a bb ccc

name: Tests

 

on: [push, pull_request]

 

jobs:

  tests:

    runs-on: ubuntu-latest

 

    steps:

      - uses: actions/checkout@v2

      - uses: actions/setup-node@v2

      - uses: cachix/install-nix-action@v13

      - uses: cachix/cachix-action@v10

        with:

          name: dapp

 

      - name: Install dependencies

        run: nix-shell --run 'make'

 

      - name: Check gas snapshots

        run: nix-shell --run 'dapp check-snapshot'

 

      - name: Run tests

        run: nix-shell --run 'dapp test'

        env:

          # Only fuzz deeply if we're pushing to main or this is a PR to main:

          DEEP_FUZZ: ${{ github.ref == 'refs/heads/main' || github.base_ref == 'main' }} {"name":"ds-test","path":"lib/ds-test","sha":"0a5da56b0d65960e6a994d2ec8245e6edd38c248","size":0,"url":"https://api.github.com/repos/Nate15872/ERC4626/contents/lib/ds-test?ref=main","html_url":"https://github.com/dapphub/ds-test/tree/0a5da56b0d65960e6a994d2ec8245e6edd38c248","git_url":"https://api.github.com/repos/dapphub/ds-test/git/trees/0a5da56b0d65960e6a994d2ec8245e6edd38c248","download_url":null,"type":"submodule","submodule_git_url":"https://github.com/dapphub/ds-test","_links":{"self":"https://api.github.com/repos/Nate15872/ERC4626/contents/lib/ds-test?ref=main","git":"https://api.github.com/repos/dapphub/ds-test/git/trees/0a5da56b0d65960e6a994d2ec8245e6edd38c248","html":"https://github.com/dapphub/ds-test/tree/0a5da56b0d65960e6a994d2ec8245e6edd38c248"}}
 


`
    
    for i, match := range re.FindAllString(str, -1) {
        fmt.Println(match, "found at index", i)
    }
}
